### PR TITLE
[BUGFIX] extension manager could not resolve dependency to static_inf…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,10 +61,7 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
-      "web-dir": ".Build/Web",
-      "Package": {
-        "partOfMinimalUsableSystem": true
-      }
+      "web-dir": ".Build/Web"
     }
   }
 }


### PR DESCRIPTION
…o_tables

when static_info_tables_zh is set to be part of the minimal usable system it gets loaded before the static_info_tables, which is a dependency. That causes an exception in the extension manager in the backend (at least in composer mode in TYPO3 6.2.x)
